### PR TITLE
feat: add support for tagging emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ const response = await lettermint.email
   .metadata({
     foo: 'bar',
   })
+  .tag('campaign-123')
   .send();
 ```
 
@@ -93,6 +94,7 @@ Methods for sending emails:
 - `route(route: string)`: Set the routing key for the email
 - `idempotencyKey(key: string)`: Set an idempotency key to prevent duplicate email sends
 - `metadata(metadata: Record<string, string>)`: Set metadata for the email
+- `tag(tag: string)`: Set a tag for the email
 - `send()`: Send the email and return a promise with the response
 
 ## License

--- a/src/endpoints/email.spec.ts
+++ b/src/endpoints/email.spec.ts
@@ -220,6 +220,23 @@ describe('EmailEndpoint', () => {
     });
   });
 
+  it('should set tag', () => {
+    const tag = 'campaign-123';
+    const result = emailEndpoint.tag(tag);
+
+    expect(result).toBe(emailEndpoint);
+
+    return emailEndpoint.send().then(() => {
+      expect(client.post).toHaveBeenCalledWith(
+        '/send',
+        expect.objectContaining({
+          tag,
+        }),
+        undefined
+      );
+    });
+  });
+
   it('should send the email with all options', async () => {
     // Set up a complete email
     emailEndpoint
@@ -236,7 +253,8 @@ describe('EmailEndpoint', () => {
       .route('test-route')
       .metadata({
         foo: 'bar',
-      });
+      })
+      .tag('campaign-123');
 
     // Send the email
     const response = await emailEndpoint.send();
@@ -270,6 +288,7 @@ describe('EmailEndpoint', () => {
           },
         ],
         route: 'test-route',
+        tag: 'campaign-123',
       },
       undefined
     );

--- a/src/endpoints/email.ts
+++ b/src/endpoints/email.ts
@@ -82,6 +82,11 @@ export interface EmailPayload {
    * The metadata object (optional)
    */
   metadata?: Record<string, string>;
+
+  /**
+   * The tag (optional)
+   */
+  tag?: string;
 }
 
 /**
@@ -299,6 +304,19 @@ export class EmailEndpoint extends Endpoint {
    */
   public metadata(metadata: Record<string, string>): this {
     this.payload.metadata = metadata;
+    return this;
+  }
+
+  /**
+   * Set the tag for the email
+   *
+   * @example tag('campaign-123')
+   *
+   * @param key A string to categorize the email
+   * @returns The current instance for chaining
+   */
+  public tag(tag: string): this {
+    this.payload.tag = tag;
     return this;
   }
 


### PR DESCRIPTION
- Introduced `tag` method to set a tag for email categorization.
- Updated `send` method and tests to handle tagging.
- Extended README with documentation and examples for `tag` functionality.