### PR TITLE
feat(email): add TLS settings, attachment MIME types, and batch idempotency

### DIFF
--- a/src/endpoints/email.spec.ts
+++ b/src/endpoints/email.spec.ts
@@ -150,7 +150,10 @@ describe('EmailEndpoint', () => {
   });
 
   it('should set custom headers', () => {
-    const headers = { 'X-Custom': 'Value', 'X-Another': 'Another Value' };
+    const headers = {
+      'Message-ID': '<ticket-123@example.com>',
+      'X-LM-Preserve-Message-ID': 'true',
+    };
     const result = emailEndpoint.headers(headers);
 
     expect(result).toBe(emailEndpoint);
@@ -204,6 +207,47 @@ describe('EmailEndpoint', () => {
             },
           ],
         }),
+        undefined
+      );
+    });
+  });
+
+  it('should add attachments with content_id and content_type', () => {
+    const result = emailEndpoint.attach('invite.ics', 'base64calendar', 'invite', 'text/calendar');
+
+    expect(result).toBe(emailEndpoint);
+
+    return emailEndpoint.send().then(() => {
+      expect(client.post).toHaveBeenCalledWith(
+        '/send',
+        expect.objectContaining({
+          attachments: [
+            {
+              filename: 'invite.ics',
+              content: 'base64calendar',
+              content_id: 'invite',
+              content_type: 'text/calendar',
+            },
+          ],
+        }),
+        undefined
+      );
+    });
+  });
+
+  it('should set per-email settings', () => {
+    const settings = {
+      track_opens: false,
+      track_clicks: true,
+      tls: 'enforced' as const,
+    };
+
+    expect(emailEndpoint.settings(settings)).toBe(emailEndpoint);
+
+    return emailEndpoint.send().then(() => {
+      expect(client.post).toHaveBeenCalledWith(
+        '/send',
+        expect.objectContaining({ settings }),
         undefined
       );
     });
@@ -399,5 +443,23 @@ describe('EmailEndpoint', () => {
         'Idempotency-Key': 'unique-id-123',
       },
     });
+  });
+
+  it('should set and reset the batch idempotency key', async () => {
+    const payload = [
+      {
+        from: 'sender@example.com',
+        to: ['recipient@example.com'],
+        subject: 'Test Subject',
+      },
+    ];
+
+    await emailEndpoint.idempotencyKey('batch-key').sendBatch(payload);
+    await emailEndpoint.sendBatch(payload);
+
+    expect(client.post).toHaveBeenNthCalledWith(1, '/send/batch', payload, {
+      headers: { 'Idempotency-Key': 'batch-key' },
+    });
+    expect(client.post).toHaveBeenNthCalledWith(2, '/send/batch', payload, undefined);
   });
 });

--- a/src/endpoints/email.ts
+++ b/src/endpoints/email.ts
@@ -175,9 +175,15 @@ export class EmailEndpoint extends Endpoint {
    * @param filename The attachment filename
    * @param content The base64-encoded file content
    * @param content_id The Content-ID for inline attachments (optional)
+   * @param content_type The MIME type for the attachment (optional)
    * @returns The current instance for chaining
    */
-  public attach(filename: string, content: string, content_id?: string): this {
+  public attach(
+    filename: string,
+    content: string,
+    content_id?: string,
+    content_type?: string
+  ): this {
     if (!this.payload.attachments) {
       this.payload.attachments = [];
     }
@@ -186,8 +192,20 @@ export class EmailEndpoint extends Endpoint {
       filename,
       content,
       ...(content_id && { content_id }),
+      ...(content_type && { content_type }),
     });
 
+    return this;
+  }
+
+  /**
+   * Set per-email delivery and tracking settings
+   *
+   * @param settings Settings that override the selected route for this email
+   * @returns The current instance for chaining
+   */
+  public settings(settings: NonNullable<EmailPayload['settings']>): this {
+    this.payload.settings = settings;
     return this;
   }
 
@@ -236,7 +254,15 @@ export class EmailEndpoint extends Endpoint {
   }
 
   public async sendBatch(payload: SendBatchMailRequest): Promise<SendBatchEmailResponse> {
-    return this.httpClient.post<SendBatchEmailResponse>('/send/batch', payload);
+    const config = this.idempotencyKeyValue
+      ? { headers: { 'Idempotency-Key': this.idempotencyKeyValue } }
+      : undefined;
+
+    try {
+      return await this.httpClient.post<SendBatchEmailResponse>('/send/batch', payload, config);
+    } finally {
+      this.reset();
+    }
   }
 
   public async ping(): Promise<string> {


### PR DESCRIPTION
## Summary

- Add per-email TLS and tracking settings to the fluent endpoint.
- Add attachment MIME type support.
- Send and reset the idempotency key for batch requests.
- Test the Message-ID preservation headers.

The generated request types were current after PR #18, but the hand-written email endpoint did not expose all Sending API options.

## Checks

- `npm run lint`
- `npm run type-check`
- `npm test -- --runInBand` — 46 tests passed
- `npm run build`