### PR TITLE
fix: expose ESM build via package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,23 @@
   "name": "lettermint",
   "version": "2.4.0",
   "description": "Official Lettermint Node.js SDK",
+  "type": "commonjs",
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "files": [
     "dist",
     "README.md",


### PR DESCRIPTION
## Summary

The SDK already builds both CJS and ESM (`tsup --format esm,cjs`), and `dist/index.mjs` plus `dist/index.d.mts` ship in the published tarball. `package.json` only declared `main`/`types`, so Node and bundlers never resolved the ESM build.

Adds a dual `exports` map that matches the files published in 2.4.0:

- `import` → `dist/index.mjs` / `dist/index.d.mts`
- `require` → `dist/index.js` / `dist/index.d.ts`

Keeps `"type": "commonjs"` so existing `require()` consumers stay unchanged.

Fixes #23

## Test plan

- [x] Confirmed 2.4.0 tarball contains `dist/index.js`, `dist/index.mjs`, `dist/index.d.ts`, and `dist/index.d.mts`
- [ ] CI green
- [ ] After merge/release, `import { Lettermint } from 'lettermint'` resolves to the ESM build